### PR TITLE
set menu margin top and bottom

### DIFF
--- a/CafeMenu/styles.css
+++ b/CafeMenu/styles.css
@@ -10,6 +10,8 @@ body {
     margin-right: auto;
     max-width: 500px;
     padding: 20px;
+    margin-top: 20px;
+    margin-bottom: 0px;
 }
 
 h1, h2, p {


### PR DESCRIPTION
On a small screen the top margin of the menu is a little wider than the bottom. So, setting the ``marging-top: 20px;``
and ``margin-bottom: 0px;`` might fix this.